### PR TITLE
Add config files from source

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,11 @@ parts:
     override-build: |
       craftctl default
 
-      install -DT COPYING $CRAFT_PART_INSTALL/usr/share/doc/COPYING
+      DOC=$CRAFT_PART_INSTALL/usr/share/doc
+      mkdir -p $DOC
+      cp COPYING $DOC/
+      # Strange location to place config files, but similar to the DEB
+      cp -vr configs $DOC/
 
       craftctl set version="$(git describe --tags | sed s/v//)+snap"
 


### PR DESCRIPTION
Adds the following config files:
```
/snap/linuxptp-rt/current/usr/share/doc/configs/
├── automotive-master.cfg
├── automotive-slave.cfg
├── default.cfg
├── E2E-TC.cfg
├── G.8265.1.cfg
├── G.8275.1.cfg
├── G.8275.2.cfg
├── gPTP.cfg
├── P2P-TC.cfg
├── snmpd.conf
├── ts2phc-generic.cfg
├── ts2phc-TC.cfg
├── UNICAST-MASTER.cfg
└── UNICAST-SLAVE.cfg

1 directory, 14 files
```