### PR TITLE
Correct comment regarding run directory creation

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -141,6 +141,6 @@ apps:
       - ptp
 
   create-run-dir-service:
-    # Makes sure /run/snap.linuxpt exists, as /run is cleared during a reboot.
+    # Create the expected run directory on install and after each boot
     command: bin/create-run-dir.sh
     daemon: oneshot


### PR DESCRIPTION
The comment should not include code as it can quickly get outdated. The given path is wrong.
Moreover, this doesn't cover the install-time creation.