### PR TITLE
Use upstream v4.4 source

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,7 +26,7 @@ parts:
     after: [local]
     plugin: make
     source: git://git.code.sf.net/p/linuxptp/code
-    source-tag: v4.0
+    source-tag: v4.4
     source-depth: 1
     # make-parameters: 
     override-build: |


### PR DESCRIPTION
- [x] Use v4.4 source from upstream
- [x] Smoke tests - two RPi5's are syncing via a PTP switch