### PR TITLE
Get upstream source using HTTP

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,8 @@ parts:
   linuxptp:
     after: [local]
     plugin: make
-    source: https://github.com/richardcochran/linuxptp.git
+    source-type: git
+    source: https://git.code.sf.net/p/linuxptp/code
     source-tag: v4.4
     source-depth: 1
     # make-parameters: 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,7 @@ parts:
   linuxptp:
     after: [local]
     plugin: make
-    source: git://git.code.sf.net/p/linuxptp/code
+    source: https://github.com/richardcochran/linuxptp.git
     source-tag: v4.4
     source-depth: 1
     # make-parameters: 


### PR DESCRIPTION
The Canonical hosted runners are not able to access the git repo on Sourceforge using the git protocol. This PR changes the protocol to HTTP.